### PR TITLE
feat: 404 ページと共通エラーページを追加

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center space-y-6 text-center">
+      <h2 className="text-2xl font-bold">エラーが発生しました</h2>
+      <p className="text-muted-foreground">
+        申し訳ありません。予期しないエラーが発生しました。
+      </p>
+      <button
+        onClick={() => reset()}
+        className="rounded bg-primary px-4 py-2 text-primary-foreground"
+      >
+        再試行
+      </button>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center space-y-6 text-center">
+      <h2 className="text-2xl font-bold">ページが見つかりません</h2>
+      <p className="text-muted-foreground">
+        お探しのページは削除されたか、URLが間違っている可能性があります。
+      </p>
+      <Link
+        href="/"
+        className="rounded bg-primary px-4 py-2 text-primary-foreground"
+      >
+        ホームに戻る
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 404 専用ページを追加
- 予期しないエラー用の共通ページと再試行ボタンを実装

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894b60769508326a25c1626275c81af