### PR TITLE
feat: Sentry 監視と共通ログユーティリティの導入

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Sentry DSN
+SENTRY_DSN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # Google Cloud service account keys and credentials
 google-service-account.json

--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.# giminiaggregation
+
+## Monitoring
+
+Sentry を用いたエラーモニタリングを導入しています。`SENTRY_DSN` 環境変数を設定すると、重大なエラー発生時に通知が送信されます。ログ出力は `src/lib/logger.ts` で共通化され、API ルートから呼び出されます。
+

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lucide-react": "^0.536.0",
     "multer": "^2.0.2",
     "next": "15.4.5",
+    "@sentry/nextjs": "^7.114.0",
     "node-fetch": "^3.3.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/src/app/api/validate-url/route.ts
+++ b/src/app/api/validate-url/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { validateGeminiUrl, ValidationResult } from '@/lib/validators/urlValidator';
 import { getClientIP, CORS_HEADERS } from '@/lib/api/utils';
 import { checkRateLimit } from '@/lib/api/rateLimiter';
+import { logInfo, logError } from '@/lib/logger';
 
 // キャッシュの有効期間（5分）
 const CACHE_TTL_MS = 5 * 60 * 1000;
@@ -93,12 +94,12 @@ export async function POST(request: NextRequest) {
     }
 
     // ログ出力（セキュリティ監査用）
-    console.log(`URL validation: ${url} - ${result.status} - IP: ${ip}`);
+    logInfo(`URL validation: ${url} - ${result.status} - IP: ${ip}`);
 
     return NextResponse.json(result, { headers: CORS_HEADERS });
 
   } catch (error) {
-    console.error('URL validation error:', error);
+    logError(error, { url });
     
     return NextResponse.json(
       {

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,33 @@
+let Sentry: any = null;
+
+try {
+  // 動的に読み込み、パッケージ未インストール時の失敗を防ぐ
+  Sentry = require('@sentry/nextjs');
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    tracesSampleRate: 1.0,
+  });
+} catch {
+  // 監視サービスが利用できない場合はログ出力のみを行う
+}
+
+export const logInfo = (message: string, context?: Record<string, unknown>) => {
+  if (context) {
+    console.log(message, context);
+  } else {
+    console.log(message);
+  }
+};
+
+export const logError = (error: unknown, context?: Record<string, unknown>) => {
+  if (context) {
+    console.error(error, context);
+  } else {
+    console.error(error);
+  }
+
+  if (Sentry) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    Sentry.captureException(err, { extra: context });
+  }
+};


### PR DESCRIPTION
## Summary
- add shared logger using Sentry DSN from environment
- call logger from validate-url API route
- pass SENTRY_DSN to CI workflow

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@sentry%2fnextjs)
- `npm test` (fails: Failed to load PostCSS config: Invalid PostCSS Plugin)


------
https://chatgpt.com/codex/tasks/task_e_6894b74e5dd08326b654420ab5fe1005