### PR TITLE
feat: add upload validation schemas

### DIFF
--- a/src/lib/schemas/uploadSchema.ts
+++ b/src/lib/schemas/uploadSchema.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const profileImageUploadSchema = z.object({
+  file: z
+    .instanceof(File, { message: "ファイルが見つかりません" })
+    .refine((file) => file.type.startsWith("image/"), {
+      message: "画像ファイルのみアップロード可能です",
+    })
+    .refine((file) => file.size <= 5 * 1024 * 1024, {
+      message: "ファイルサイズは5MB以下にしてください",
+    }),
+});
+
+export const refreshProfileImageUrlSchema = z.object({
+  fileName: z.string().min(1, "ファイル名が必要です"),
+});
+
+export type ProfileImageUploadForm = z.infer<typeof profileImageUploadSchema>;
+export type RefreshProfileImageUrlInput = z.infer<typeof refreshProfileImageUrlSchema>;
+


### PR DESCRIPTION
## Summary
- add Zod schema for profile image uploads
- validate profile image upload and refresh URL APIs with common error handling

## Testing
- `npm test` *(fails: Failed to load PostCSS config)*
- `npm run lint` *(fails: no-require-imports errors)*

------
https://chatgpt.com/codex/tasks/task_e_6894b76279f48326969b47e23443c376