### PR TITLE
test: add API and component tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "predev": "node scripts/kill-port.js 3000",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.16.0",

--- a/src/__tests__/navbar.test.tsx
+++ b/src/__tests__/navbar.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { Navbar } from '@/components/Navbar';
+
+vi.mock('next/link', () => ({
+  default: ({ children, ...props }: any) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('next/image', () => ({
+  default: (props: any) => <img {...props} />,
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ isAuthenticated: false }),
+}));
+
+vi.mock('@/hooks/useUserProfile', () => ({
+  useUserProfile: () => ({ userProfile: null }),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  loginWithGoogle: vi.fn(),
+  logout: vi.fn(),
+}));
+
+describe('Navbar component', () => {
+  it('renders navigation links', () => {
+    const html = renderToString(<Navbar />);
+    expect(html).toContain('ランキング');
+    expect(html).toContain('カテゴリ');
+    expect(html).toContain('コラム');
+  });
+});

--- a/src/__tests__/posts-get.test.ts
+++ b/src/__tests__/posts-get.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/posts/route';
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  getDocs: vi.fn(),
+  query: vi.fn(() => ({})),
+  where: vi.fn(() => ({})),
+  limit: vi.fn(() => ({})),
+}));
+
+vi.mock('@/lib/firebase', () => ({ db: {} }));
+
+vi.mock('@/lib/api/utils', () => ({
+  getClientIP: () => '127.0.0.1',
+  createErrorResponse: (code: string, message: string, status = 400) =>
+    new Response(JSON.stringify({ code, message }), { status }),
+  createSuccessResponse: (data: any, message = 'ok', status = 200) =>
+    new Response(JSON.stringify({ ...data, message }), { status }),
+}));
+
+vi.mock('@/lib/api/rateLimiter', () => ({
+  checkRateLimit: vi.fn(() => Promise.resolve(true)),
+}));
+
+const { getDocs } = require('firebase/firestore');
+const { checkRateLimit } = require('@/lib/api/rateLimiter');
+
+describe('GET /api/posts', () => {
+  it('returns posts successfully', async () => {
+    (getDocs as any).mockResolvedValueOnce({
+      docs: [
+        {
+          id: 'p1',
+          data: () => ({
+            title: 't1',
+            url: 'u1',
+            description: 'd1',
+            tagIds: [],
+            categoryId: 'other',
+            tags: [],
+            isPublic: true,
+            createdAt: { toDate: () => new Date('2020-01-01') },
+            favoriteCount: 0,
+            views: 0,
+          }),
+        },
+      ],
+    });
+
+    const req = new NextRequest('http://localhost/api/posts');
+    const res = await GET(req);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.posts).toHaveLength(1);
+  });
+
+  it('handles rate limit errors', async () => {
+    checkRateLimit.mockResolvedValueOnce(false);
+
+    const req = new NextRequest('http://localhost/api/posts');
+    const res = await GET(req);
+    const json = await res.json();
+    expect(res.status).toBe(429);
+    expect(json.code).toBe('rate_limited');
+  });
+
+  it('handles server errors', async () => {
+    (getDocs as any).mockRejectedValueOnce(new Error('firestore error'));
+
+    const req = new NextRequest('http://localhost/api/posts');
+    const res = await GET(req);
+    const json = await res.json();
+    expect(res.status).toBe(500);
+    expect(json.code).toBe('server_error');
+  });
+});

--- a/src/__tests__/profile-setup.test.tsx
+++ b/src/__tests__/profile-setup.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { ProfileSetup } from '@/components/ProfileSetup';
+
+vi.mock('next/image', () => ({
+  default: (props: any) => <img {...props} />,
+}));
+
+vi.mock('browser-image-compression', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('@/lib/userProfile', () => ({
+  setupUserProfile: vi.fn(),
+  generateUniquePublicId: vi.fn(async () => 'public123'),
+}));
+
+describe('ProfileSetup component', () => {
+  it('renders form fields', () => {
+    const html = renderToString(<ProfileSetup uid="u1" onComplete={() => {}} />);
+    expect(html).toContain('公開ID');
+    expect(html).toContain('ユーザー名');
+  });
+});


### PR DESCRIPTION
## Summary
- add GET posts API unit tests and error cases
- add basic rendering tests for Navbar and ProfileSetup components
- update npm test script to run Vitest once

## Testing
- `npm install --legacy-peer-deps` (fails: 403 Forbidden)
- `npm test` (fails: vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_6894bf5d761c8326a6f716811c4adae1