### PR TITLE
Sanitize column and post content

### DIFF
--- a/src/__tests__/columnDetail.test.tsx
+++ b/src/__tests__/columnDetail.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { ColumnDetail } from '@/components/columns/ColumnDetail';
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img {...props} alt={props.alt} />;
+  }
+}));
+
+describe('ColumnDetail sanitization', () => {
+  it('removes script tags from body', () => {
+    const column = {
+      id: '1',
+      title: 'title',
+      slug: 'slug',
+      author: 'author',
+      excerpt: 'excerpt',
+      category: 'cat',
+      createdAt: new Date(),
+      views: 0,
+      likes: 0,
+      isPublished: true,
+      body: '<p>safe</p><script>alert(1)</script>'
+    };
+
+    const html = renderToString(<ColumnDetail column={column} />);
+    expect(html).toContain('<p>safe</p>');
+    expect(html).not.toContain('<script>');
+  });
+});

--- a/src/__tests__/sanitizeHtml.test.ts
+++ b/src/__tests__/sanitizeHtml.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeHtml } from '@/lib/sanitizeHtml';
+
+describe('sanitizeHtml', () => {
+  it('removes script tags', () => {
+    const dirty = '<div>test</div><script>alert(1)</script>';
+    const clean = sanitizeHtml(dirty);
+    expect(clean).toBe('<div>test</div>');
+  });
+});

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -4,6 +4,7 @@ import { db } from '@/lib/firebase';
 import { postSchema } from '@/lib/schemas/postSchema';
 import { validateGeminiUrl } from '@/lib/validators/urlValidator';
 import { getUserProfile } from '@/lib/userProfile';
+import { sanitizeHtml } from '@/lib/sanitizeHtml';
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -260,10 +261,12 @@ export async function POST(request: NextRequest) {
     }
 
     // 投稿データの準備
+    const sanitizedTitle = sanitizeHtml(formData.title);
+    const sanitizedDescription = sanitizeHtml(formData.description);
     const postData = {
-      title: formData.title,
+      title: sanitizedTitle,
       url: formData.url,
-      description: formData.description,
+      description: sanitizedDescription,
       tagIds: tagIds, // タグID配列
       categoryId: categoryObj.id, // カテゴリID
       ...(formData.category === 'その他' && formData.customCategory

--- a/src/components/columns/ColumnDetail.tsx
+++ b/src/components/columns/ColumnDetail.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { Eye, Heart, Calendar } from 'lucide-react';
 import type { Column } from '@/types/Column';
 import { formatDate } from '@/lib/utils/date';
+import { sanitizeHtml } from '@/lib/sanitizeHtml';
 
 interface ColumnDetailProps {
   column: Column;
@@ -100,7 +101,9 @@ export function ColumnDetail({ column }: ColumnDetailProps) {
             fontFamily: 'system-ui, -apple-system, sans-serif'
           }}
           dangerouslySetInnerHTML={{
-            __html: column.body || '<p>本文が読み込まれていません。</p>'
+            __html: sanitizeHtml(
+              column.body || '<p>本文が読み込まれていません。</p>'
+            )
           }}
         />
 

--- a/src/lib/sanitizeHtml.ts
+++ b/src/lib/sanitizeHtml.ts
@@ -1,0 +1,5 @@
+export function sanitizeHtml(html: string): string {
+  if (!html) return '';
+  // Remove script tags and their content
+  return html.replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '');
+}


### PR DESCRIPTION
## Summary
- Sanitize column body HTML before rendering
- Sanitize post title and description before saving
- Add tests for HTML sanitization

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894bf2ef25c8326b0728216055a4341