### PR TITLE
Restrict Firestore reads to public posts

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,7 +2,7 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /posts/{postId} {
-      allow read: if true;
+      allow read: if resource.data.isPublic == true;
       allow create: if request.auth != null && request.resource.data.favoriteCount == 0;
       allow update, delete: if request.auth != null &&
         request.resource.data.favoriteCount == resource.data.favoriteCount;

--- a/scripts/test-firestore-rules.js
+++ b/scripts/test-firestore-rules.js
@@ -1,0 +1,22 @@
+const { initializeTestEnvironment, assertFails, assertSucceeds } = require('@firebase/rules-unit-testing');
+const fs = require('fs');
+
+(async () => {
+  const testEnv = await initializeTestEnvironment({
+    projectId: 'demo-test',
+    firestore: { rules: fs.readFileSync('firestore.rules', 'utf8') },
+  });
+
+  const clientCtx = testEnv.unauthenticatedContext();
+  await testEnv.withSecurityRulesDisabled(async (context) => {
+    await context.firestore().collection('posts').doc('public').set({ isPublic: true });
+    await context.firestore().collection('posts').doc('private').set({ isPublic: false });
+  });
+
+  const db = clientCtx.firestore();
+
+  await assertSucceeds(db.collection('posts').doc('public').get());
+  await assertFails(db.collection('posts').doc('private').get());
+
+  await testEnv.cleanup();
+})();

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -186,7 +186,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { formData, userInfo } = body;
+    const { userInfo } = body;
+    const formData = validationResult.data;
 
     // AuthorizationヘッダーからIDトークンを取得
     const authHeader = request.headers.get('authorization');
@@ -270,7 +271,7 @@ export async function POST(request: NextRequest) {
         ? { customCategory: formData.customCategory }
         : {}),
       thumbnailUrl: formData.thumbnailUrl || '',
-      isPublic: formData.isPublic !== false, // デフォルトはtrue
+      isPublic: formData.isPublic,
       
       // システム自動設定項目
       authorId: userInfo.uid,


### PR DESCRIPTION
## Summary
- limit Firestore post reads to documents flagged public
- validate post data using server-side schema and persist isPublic flag
- add script to verify Firestore rules via emulator

## Testing
- `npm test` *(fails: vitest: not found)*
- `npx firebase emulators:exec "node scripts/test-firestore-rules.js"` *(fails: 403 Forbidden - GET https://registry.npmjs.org/firebase)*

------
https://chatgpt.com/codex/tasks/task_e_6894bf7eabd48326b46b233e55acbec5