### PR TITLE
環境変数の検証と共通利用を実装

### DIFF
--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -13,14 +13,15 @@ import {
 import { checkRateLimit } from '@/lib/api/rateLimiter';
 import { getAuth } from 'firebase-admin/auth';
 import { initializeApp, getApps, cert } from 'firebase-admin/app';
+import { env } from '@/lib/env';
 
 // Firebase Admin初期化
 if (!getApps().length) {
   initializeApp({
     credential: cert({
-      projectId: process.env.GOOGLE_CLOUD_PROJECT_ID,
-      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      projectId: env.GOOGLE_CLOUD_PROJECT_ID,
+      clientEmail: env.FIREBASE_CLIENT_EMAIL,
+      privateKey: env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
     }),
   });
 }
@@ -292,7 +293,7 @@ export async function POST(request: NextRequest) {
       const docRef = await addDoc(collection(db, 'posts'), postData);
 
       // 分散カウンター用のシャードを初期化
-      const SHARD_COUNT = parseInt(process.env.FAVORITE_SHARD_COUNT || '10', 10);
+      const SHARD_COUNT = env.FAVORITE_SHARD_COUNT;
       const shardPromises = Array.from({ length: SHARD_COUNT }).map((_, idx) =>
         setDoc(doc(db, `posts/${docRef.id}/favoriteShards/${idx}`), { count: 0 })
       );

--- a/src/app/api/refresh-profile-image-url/route.ts
+++ b/src/app/api/refresh-profile-image-url/route.ts
@@ -5,24 +5,25 @@ import { initializeApp, getApps, cert } from 'firebase-admin/app';
 import { createErrorResponse, createSuccessResponse } from '@/lib/api/utils';
 import { refreshProfileImageUrlSchema } from '@/lib/schemas/uploadSchema';
 
+import { env } from '@/lib/env';
 // Firebase Admin初期化
 if (!getApps().length) {
   initializeApp({
     credential: cert({
-      projectId: process.env.GOOGLE_CLOUD_PROJECT_ID,
-      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      projectId: env.GOOGLE_CLOUD_PROJECT_ID,
+      clientEmail: env.FIREBASE_CLIENT_EMAIL,
+      privateKey: env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
     }),
   });
 }
 
 // Google Cloud Storage初期化
 const storage = new Storage({
-  projectId: process.env.GOOGLE_CLOUD_PROJECT_ID,
-  keyFilename: process.env.GOOGLE_APPLICATION_CREDENTIALS,
+  projectId: env.GOOGLE_CLOUD_PROJECT_ID,
+  keyFilename: env.GOOGLE_APPLICATION_CREDENTIALS,
 });
 
-const bucket = storage.bucket(process.env.GOOGLE_CLOUD_STORAGE_BUCKET!);
+const bucket = storage.bucket(env.GOOGLE_CLOUD_STORAGE_BUCKET!);
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/app/api/upload-profile-image/route.ts
+++ b/src/app/api/upload-profile-image/route.ts
@@ -4,25 +4,26 @@ import { getAuth } from 'firebase-admin/auth';
 import { initializeApp, getApps, cert } from 'firebase-admin/app';
 import { createErrorResponse, createSuccessResponse } from '@/lib/api/utils';
 import { profileImageUploadSchema } from '@/lib/schemas/uploadSchema';
+import { env } from '@/lib/env';
 
 // Firebase Admin初期化
 if (!getApps().length) {
   initializeApp({
     credential: cert({
-      projectId: process.env.GOOGLE_CLOUD_PROJECT_ID,
-      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      projectId: env.GOOGLE_CLOUD_PROJECT_ID,
+      clientEmail: env.FIREBASE_CLIENT_EMAIL,
+      privateKey: env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
     }),
   });
 }
 
 // Google Cloud Storage初期化
 const storage = new Storage({
-  projectId: process.env.GOOGLE_CLOUD_PROJECT_ID,
-  keyFilename: process.env.GOOGLE_APPLICATION_CREDENTIALS,
+  projectId: env.GOOGLE_CLOUD_PROJECT_ID,
+  keyFilename: env.GOOGLE_APPLICATION_CREDENTIALS,
 });
 
-const bucket = storage.bucket(process.env.GOOGLE_CLOUD_STORAGE_BUCKET!);
+const bucket = storage.bucket(env.GOOGLE_CLOUD_STORAGE_BUCKET!);
 
 export async function POST(request: NextRequest) {
   try {

--- a/src/app/api/verify-recaptcha/route.ts
+++ b/src/app/api/verify-recaptcha/route.ts
@@ -2,9 +2,10 @@ import { NextRequest } from 'next/server';
 import crypto from 'crypto';
 import { createErrorResponse, createSuccessResponse, getClientIP } from '@/lib/api/utils';
 import { checkRateLimit } from '@/lib/api/rateLimiter';
+import { env } from '@/lib/env';
 
 const RECAPTCHA_ENDPOINT = 'https://www.google.com/recaptcha/api/siteverify';
-const MIN_SCORE = parseFloat(process.env.RECAPTCHA_MIN_SCORE || '0.5');
+const MIN_SCORE = env.RECAPTCHA_MIN_SCORE;
 
 export async function POST(request: NextRequest) {
   try {
@@ -23,7 +24,7 @@ export async function POST(request: NextRequest) {
     console.log(`favorite verify: ipHash=${ipHash}, ua=${ua}`);
 
     const params = new URLSearchParams({
-      secret: process.env.RECAPTCHA_SECRET_KEY || '',
+      secret: env.RECAPTCHA_SECRET_KEY,
       response: token,
     });
     const verifyRes = await fetch(RECAPTCHA_ENDPOINT, {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { Layout } from "@/components/Layout";
 import { Inter } from "next/font/google";
+import { env } from '@/lib/env';
 
 const inter = Inter({
   subsets: ["latin"],
@@ -22,7 +23,7 @@ export default function RootLayout({
     <html lang="ja">
       <head>
         <script
-          src={`https://www.google.com/recaptcha/api.js?render=${process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}`}
+          src={`https://www.google.com/recaptcha/api.js?render=${env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}`}
           async
           defer
         />

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -14,6 +14,7 @@ import Image from "next/image";
 import type { Post } from "@/types/Post";
 import { formatDate } from '@/lib/utils/date';
 import { findCategoryById } from '@/lib/constants/categories';
+import { env } from '@/lib/env';
 
 declare global {
   interface Window {
@@ -85,12 +86,12 @@ export default function PostDetailPage() {
         });
       }
       
-      if (!process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY) {
+      if (!env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY) {
         throw new Error("reCAPTCHA site key not configured");
       }
       
       const token = await window.grecaptcha?.execute(
-        process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY,
+        env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY,
         { action: "favorite" }
       );
       

--- a/src/lib/api/utils.ts
+++ b/src/lib/api/utils.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server';
 import { randomUUID } from 'crypto';
+import { env } from '@/lib/env';
 
 // Determine allowed origin based on environment
 const allowedOrigin =
-  process.env.NODE_ENV === 'production'
-    ? process.env.CORS_ALLOWED_ORIGIN_PROD
-    : process.env.CORS_ALLOWED_ORIGIN_DEV;
+  env.NODE_ENV === 'production'
+    ? env.CORS_ALLOWED_ORIGIN_PROD
+    : env.CORS_ALLOWED_ORIGIN_DEV;
 
 // CORS headers configuration
 export const CORS_HEADERS = {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+const clientSchema = z.object({
+  NEXT_PUBLIC_FIREBASE_API_KEY: z.string(),
+  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: z.string(),
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID: z.string(),
+  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: z.string(),
+  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: z.string(),
+  NEXT_PUBLIC_FIREBASE_APP_ID: z.string(),
+  NEXT_PUBLIC_RECAPTCHA_SITE_KEY: z.string(),
+});
+
+const serverSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  CORS_ALLOWED_ORIGIN_PROD: z.string(),
+  CORS_ALLOWED_ORIGIN_DEV: z.string(),
+  SENTRY_DSN: z.string().optional(),
+  REDIS_HOST: z.string(),
+  REDIS_PORT: z.coerce.number(),
+  REDIS_PASSWORD: z.string().optional(),
+  REDIS_DB: z.coerce.number(),
+  REDIS_ENABLED: z.coerce.boolean().optional(),
+  RECAPTCHA_MIN_SCORE: z.coerce.number().default(0.5),
+  RECAPTCHA_SECRET_KEY: z.string(),
+  GOOGLE_CLOUD_PROJECT_ID: z.string(),
+  FIREBASE_CLIENT_EMAIL: z.string(),
+  FIREBASE_PRIVATE_KEY: z.string(),
+  GOOGLE_APPLICATION_CREDENTIALS: z.string(),
+  GOOGLE_CLOUD_STORAGE_BUCKET: z.string(),
+  FAVORITE_SHARD_COUNT: z.coerce.number().default(10),
+});
+
+const clientEnv = clientSchema.safeParse(process.env);
+if (!clientEnv.success) {
+  console.error('Invalid client environment variables:', clientEnv.error.flatten().fieldErrors);
+  throw new Error('Invalid client environment variables');
+}
+
+let serverEnv: z.infer<typeof serverSchema> = {} as any;
+if (typeof window === 'undefined') {
+  const parsed = serverSchema.safeParse(process.env);
+  if (!parsed.success) {
+    console.error('Invalid server environment variables:', parsed.error.flatten().fieldErrors);
+    process.exit(1);
+  }
+  serverEnv = parsed.data;
+}
+
+export const env = { ...clientEnv.data, ...serverEnv };

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -2,14 +2,15 @@ import { initializeApp, getApps, getApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
+import { env } from './env';
 
 const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!,
+  apiKey: env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,10 +1,11 @@
+import { env } from './env';
 let Sentry: any = null;
 
 try {
   // 動的に読み込み、パッケージ未インストール時の失敗を防ぐ
   Sentry = require('@sentry/nextjs');
   Sentry.init({
-    dsn: process.env.SENTRY_DSN,
+    dsn: env.SENTRY_DSN,
     tracesSampleRate: 1.0,
   });
 } catch {

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,4 +1,5 @@
 import Redis from 'ioredis';
+import { env } from './env';
 
 // Redis connection instance
 let redis: Redis | null = null;
@@ -7,10 +8,10 @@ let redis: Redis | null = null;
  * Redis connection configuration
  */
 const REDIS_CONFIG = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: parseInt(process.env.REDIS_PORT || '6379', 10),
-  password: process.env.REDIS_PASSWORD || undefined,
-  db: parseInt(process.env.REDIS_DB || '0', 10),
+  host: env.REDIS_HOST,
+  port: env.REDIS_PORT,
+  password: env.REDIS_PASSWORD,
+  db: env.REDIS_DB,
   connectTimeout: 2000,
   lazyConnect: true,
   maxRetriesPerRequest: 1,
@@ -24,7 +25,7 @@ const REDIS_CONFIG = {
  */
 export async function initRedis(): Promise<Redis | null> {
   // Skip Redis in development if not explicitly enabled
-  if (process.env.NODE_ENV === 'development' && !process.env.REDIS_ENABLED) {
+  if (env.NODE_ENV === 'development' && !env.REDIS_ENABLED) {
     console.log('Redis disabled in development environment');
     return null;
   }


### PR DESCRIPTION
## 概要
- `zod` を用いた環境変数の検証ロジックを追加
- 各モジュールで `env` から検証済み値を参照するよう変更

## テスト
- `npm test` (vitest が見つからず失敗)
- `npm run lint` (next が見つからず失敗)

------
https://chatgpt.com/codex/tasks/task_e_6894be95ea3c8326b068c3658374ca67