### PR TITLE
Restrict post updates and deletions to authors or admins

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -4,8 +4,11 @@ service cloud.firestore {
     match /posts/{postId} {
       allow read: if resource.data.isPublic == true;
       allow create: if request.auth != null && request.resource.data.favoriteCount == 0;
-      allow update, delete: if request.auth != null &&
+      allow update: if request.auth != null &&
+        request.auth.uid == resource.data.authorId &&
         request.resource.data.favoriteCount == resource.data.favoriteCount;
+      allow delete: if request.auth != null &&
+        (request.auth.uid == resource.data.authorId || request.auth.token.admin == true);
 
       match /favorites/{uid} {
         allow read: if true;


### PR DESCRIPTION
## Summary
- allow only authors to update posts
- allow only authors or admins to delete posts

## Testing
- `npx firebase emulators:exec "npm test"` *(fails: 403 Forbidden - GET https://registry.npmjs.org/firebase)*
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894c64834c883268be1450e8daeb36b